### PR TITLE
Fix fingerprint match failure in trident devices

### DIFF
--- a/app/src/main/java/com/credenceid/sdkapp/pages/FingerprintPage.java
+++ b/app/src/main/java/com/credenceid/sdkapp/pages/FingerprintPage.java
@@ -572,7 +572,14 @@ public class FingerprintPage extends LinearLayout implements PageView {
                         /* Call method to convert Bitmap to FMD template and match it against first
                          * FMD template created.
                          */
-                        convertToFmdAndMatch(bitmap_finger1);
+                        if (hasFmdMatcher) {
+                            //If the scan is for split fingers, then consider first fingerprint for matching
+                            if (scanType.equals(ScanType.TWO_FINGERS_SPLIT))
+                                convertToFmdAndMatch(bitmap_finger1);
+                            else
+                                convertToFmdAndMatch(bm);
+                        } else
+                            Log.w(TAG, "Fmd matcher is not present");
                     }
                 }
 


### PR DESCRIPTION
The bug was due to passing a wrong bitmap fingerprint image to the
convertToFmdAndMatch method. The issue was present only in trident
devices due to the fact that the wrong bitmap was passed only when
fingerprint is captured using OnFingerprintGrabbedFullListener.
This usage is only in trident devices.

The fix takes into account which type of fingerprint is being compared
and passes the correct fingerprint bitmap to the convertToFmdAndMatch
method. If the scan type is two fingers split, then only first
fingerprint bitmap is compared.