### PR TITLE
Fix fingerprint capture crash on Android 7.0/7.1 (java.time used below minSdk 24)

### DIFF
--- a/app/src/main/java/com/credenceid/sdkapp/FingerprintActivity.kt
+++ b/app/src/main/java/com/credenceid/sdkapp/FingerprintActivity.kt
@@ -13,17 +13,24 @@ import android.provider.MediaStore
 import android.util.Log
 import android.view.View
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import com.credenceid.biometrics.Biometrics.*
 import com.credenceid.biometrics.Biometrics.FMDFormat.ISO_19794_2_2005
 import com.credenceid.biometrics.Biometrics.ResultCode.*
 import com.credenceid.sdkapp.databinding.ActFpBinding
 import com.util.HexUtils
 import java.io.OutputStream
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 private const val SYNC_API_TIMEOUT_MS = 3000
+
+/**
+ * Timestamp appended to each captured fingerprint image saved to the gallery. "java.time" is not
+ * available below API 26, so this is formatted with "SimpleDateFormat" which this application's
+ * minSdk of 24 does support.
+ */
+private const val CAPTURE_TIMESTAMP_PATTERN = "yyyy-MM-dd_HH:mm:ss"
 
 @SuppressLint("StaticFieldLeak")
 class FingerprintActivity : Activity() {
@@ -273,7 +280,6 @@ class FingerprintActivity : Activity() {
         App.BioManager!!.grabFingerprint(
             mScanTypes[0],
             object : OnFingerprintGrabbedWSQNewListener {
-                @RequiresApi(Build.VERSION_CODES.O)
                 @SuppressLint("SetTextI18n")
 
                 override fun onFingerprintGrabbed(
@@ -302,9 +308,8 @@ class FingerprintActivity : Activity() {
                             /* Create template from fingerprint image. */
                             if (bitmap != null) {
                                 createFMDTemplate(bitmap)
-                                val currentDateTime = LocalDateTime.now()
-                                val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH:mm:ss")
-                                val formattedDate = currentDateTime.format(formatter)
+                                val formatter = SimpleDateFormat(CAPTURE_TIMESTAMP_PATTERN, Locale.US)
+                                val formattedDate = formatter.format(Date())
                                 saveBitmapToGallery(
                                     this@FingerprintActivity,
                                     bitmap,

--- a/app/src/test/java/com/credenceid/sdkapp/MinSdkApiLevelTest.kt
+++ b/app/src/test/java/com/credenceid/sdkapp/MinSdkApiLevelTest.kt
@@ -1,0 +1,77 @@
+package com.credenceid.sdkapp
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import java.net.URLDecoder
+import java.util.jar.JarFile
+
+/**
+ * This module declares "minSdk 24", but the "java.time" package was only added to Android in API
+ * 26. A reference to it from application code compiles and passes Lint, yet resolves to nothing on
+ * an API 24/25 device, so the first instruction which touches it throws NoClassDefFoundError.
+ *
+ * Annotating a method with "@RequiresApi" does not help when that method is a listener the
+ * CredenceSDK invokes, since nothing checks Build.VERSION.SDK_INT before the callback runs.
+ *
+ * This test scans the compiled application classes so a re-introduction is caught by the build
+ * instead of by a device in the field.
+ */
+class MinSdkApiLevelTest {
+
+    @Test
+    fun applicationClassesDoNotReferenceJavaTime() {
+        val offenders = compiledApplicationClasses()
+            .filter { (_, bytecode) -> bytecode.referencesType(JAVA_TIME) }
+            .keys
+            .sorted()
+
+        assertEquals(
+            "Classes referencing \"$JAVA_TIME\", which requires API 26, above a minSdk of 24",
+            emptyList<String>(),
+            offenders
+        )
+    }
+
+    /**
+     * Reads every compiled class of this application, keyed by class file path. Depending on the
+     * variant, Gradle hands unit tests either a directory of classes or a jar holding them.
+     *
+     * @return Map of class file path to that class file's bytecode.
+     */
+    private fun compiledApplicationClasses(): Map<String, ByteArray> {
+        val marker = javaClass.classLoader?.getResource(MARKER_CLASS)
+            ?: error("Unable to locate compiled application classes, looked for $MARKER_CLASS.")
+
+        if ("jar" != marker.protocol) {
+            val packageDirectory = File(marker.toURI()).parentFile
+                ?: error("Unable to locate compiled application classes, looked for $MARKER_CLASS.")
+            return packageDirectory.walkTopDown()
+                .filter { it.isFile && CLASS_EXTENSION == it.extension }
+                .associate { PACKAGE_PATH + it.name to it.readBytes() }
+        }
+
+        val jarPath = URLDecoder.decode(marker.path.substringBefore("!").removePrefix("file:"), "UTF-8")
+        JarFile(File(jarPath)).use { jar ->
+            return jar.entries().asSequence()
+                .filter { it.name.startsWith(PACKAGE_PATH) && it.name.endsWith(".$CLASS_EXTENSION") }
+                .associate { it.name to jar.getInputStream(it).readBytes() }
+        }
+    }
+
+    /**
+     * Class file constant pools store type names as UTF-8, so a byte-preserving decode is enough to
+     * find a reference without pulling in a bytecode parsing library.
+     *
+     * @return True if this bytecode names the given type, false otherwise.
+     */
+    private fun ByteArray.referencesType(type: String): Boolean =
+        String(this, Charsets.ISO_8859_1).contains(type)
+
+    companion object {
+        private const val PACKAGE_PATH = "com/credenceid/sdkapp/"
+        private const val MARKER_CLASS = PACKAGE_PATH + "App.class"
+        private const val CLASS_EXTENSION = "class"
+        private const val JAVA_TIME = "java/time/"
+    }
+}


### PR DESCRIPTION
This PR proposes a fix for the fingerprint capture crash on Android 7.0 and 7.1, where `FingerprintActivity` calls `java.time` below the `minSdk 24` this module declares. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/178. You can sign in with your GitHub ID to claim ownership of the project.

## What is wrong

`app/build.gradle` declares `minSdk 24`, but the `java.time` package was only added to Android in API 26. Since cbb5bd3, `captureFingerprintOne()` formats the gallery file name with `LocalDateTime.now()` and `DateTimeFormatter.ofPattern(...)`, so on an Android 7.0 or 7.1 device the very first successful fingerprint capture throws `NoClassDefFoundError` from inside the `OnFingerprintGrabbedWSQNewListener` callback — the app's headline feature, on devices `app/build.gradle` says are supported.

The `@RequiresApi(Build.VERSION_CODES.O)` annotation on that override records the API requirement but cannot enforce it: the callback is invoked by the CredenceSDK, and nothing checks `Build.VERSION.SDK_INT` before it runs. That is also why Android Lint stays quiet — the annotation suppresses `NewApi` at the very site where the guarantee is not available, so `./gradlew lintDebug` reports zero errors while the shipped APK carries the unguarded reference.

## Reproducing it on master

Built from `master` at `cbb5bd3`, with no changes:

```
$ ./gradlew assembleDebug
BUILD SUCCESSFUL in 1m 21s

$ $ANDROID_HOME/build-tools/34.0.0/aapt2 dump badging app/build/outputs/apk/debug/app-debug.apk | grep sdkVersion
sdkVersion:'24'
targetSdkVersion:'34'

$ unzip -o -q app/build/outputs/apk/debug/app-debug.apk 'classes*.dex' -d /tmp/dex
$ $ANDROID_HOME/build-tools/34.0.0/dexdump -d /tmp/dex/classes*.dex | grep 'java/time'
00a6: invoke-static {}, Ljava/time/LocalDateTime;.now:()Ljava/time/LocalDateTime;
00ac: invoke-static {v1}, Ljava/time/format/DateTimeFormatter;.ofPattern:(Ljava/lang/String;)Ljava/time/format/DateTimeFormatter;
00b0: invoke-virtual {v0, v1}, Ljava/time/LocalDateTime;.format:(Ljava/time/format/DateTimeFormatter;)Ljava/lang/String;
```

Those three instructions live in `Lcom/credenceid/sdkapp/FingerprintActivity$captureFingerprintOne$1;.onFingerprintGrabbed`, in an APK whose own manifest declares API 24 as the floor. I do not have a CredenceID unit running Android 7 to hand, so the artifact above is the evidence I can offer rather than a device log — the runtime consequence of an unresolvable type reference on API 24/25 follows from it directly.

## The change

`SimpleDateFormat` is available from API 1 and produces the identical string for this pattern, so the timestamp is now built with it and the misleading `@RequiresApi` is dropped. The pattern itself is untouched, so saved file names do not change. I checked the two formatters against each other on a fixed instant across several default time zones:

```
UTC               java.time=2026-08-06_07:06:40  SimpleDateFormat=2026-08-06_07:06:40  equal=true
America/New_York  java.time=2026-08-06_03:06:40  SimpleDateFormat=2026-08-06_03:06:40  equal=true
Asia/Kolkata      java.time=2026-08-06_12:36:40  SimpleDateFormat=2026-08-06_12:36:40  equal=true
Europe/Paris      java.time=2026-08-06_09:06:40  SimpleDateFormat=2026-08-06_09:06:40  equal=true
```

`Locale.US` is passed explicitly so the numeric fields cannot come out as locale-specific digits in a file name; that is the one intentional difference from the previous call, and it only ever narrows the output to ASCII.

The two alternatives are yours to prefer over this one, and both are larger: enabling core library desugaring (`coreLibraryDesugaringEnabled` plus a `desugar_jdk_libs` dependency) keeps `java.time` at the cost of new build configuration in a sample app people copy from, and raising `minSdk` to 26 drops the Android 7 devices your current setting supports. I took the smallest option that keeps your declared floor working; happy to switch if you would rather go one of the other ways.

## Verifying it

`app/src/test` did not exist, though `testImplementation 'junit:junit:4.13.2'` was already declared, so this adds it with one test. `MinSdkApiLevelTest` scans the compiled application classes for `java/time/` references, which fails on `master` naming the exact offender and passes after the fix:

```
$ ./gradlew testDebugUnitTest        # on master, with the test applied
MinSdkApiLevelTest > applicationClassesDoNotReferenceJavaTime FAILED
    java.lang.AssertionError: Classes referencing "java/time/", which requires API 26, above a minSdk of 24 expected:<[]> but was:<[com/credenceid/sdkapp/FingerprintActivity$captureFingerprintOne$1.class]>

$ ./gradlew clean assembleDebug testDebugUnitTest lintDebug    # with the fix
BUILD SUCCESSFUL in 44s
```

The test is scoped to `com.credenceid.sdkapp` on purpose: `androidx` and the Kotlin stdlib also ship `java.time` references, but theirs sit behind `Api34Impl`-style guards or in extensions this app never calls, so widening the scan would only produce noise. Against a clean baseline build of `master`, the Kotlin warning set is byte-identical before and after (28 warnings either way, same lines), and `lintDebug` reports the same 54 warnings and nothing at error severity on both trees — nothing that was green went red.

## How this was managed

This work was tracked as [Fingerprint capture crashes on API 24 and 25 devices](https://eastagiletracker.com/projects/178/stories/50174) on a board imported from this repository's own issues and pull requests, which is browsable at https://eastagiletracker.com/projects/178.

![board](https://raw.githubusercontent.com/eastagiletracker/capp_SampleApp/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
